### PR TITLE
Facebook Strategy: Include the profile picture in the payload

### DIFF
--- a/src/strategies/facebook.ts
+++ b/src/strategies/facebook.ts
@@ -217,7 +217,7 @@ export class FacebookStrategy<User> extends OAuth2Strategy<
 				familyName: raw.last_name,
 			},
 			emails: [{ value: raw.email }],
-			photos: [{ value: raw.picture }],
+			photos: [{ value: raw.picture.data.url }],
 			_json: raw,
 		};
 		return profile;

--- a/src/strategies/facebook.ts
+++ b/src/strategies/facebook.ts
@@ -84,6 +84,7 @@ export type AdditionalFacebookProfileField =
 	| 'name_format'
 	| 'payment_pricepoints'
 	| 'political'
+	| 'picture'
 	| 'profile_pic'
 	| 'quotes'
 	| 'relationship_status'
@@ -103,6 +104,7 @@ export const baseProfileFields = [
 	'first_name',
 	'middle_name',
 	'last_name',
+	'picture',
 ];
 
 export const FacebookDefaultScopes: FacebookScope[] = ['public_profile', 'email'];
@@ -204,6 +206,7 @@ export class FacebookStrategy<User> extends OAuth2Strategy<
 			},
 		);
 		const raw: FacebookProfile['_json'] = await response.json();
+		// Default Public Profile Fields: https://developers.facebook.com/docs/graph-api/reference/user/#fields
 		const profile: FacebookProfile = {
 			provider: SocialsProvider.FACEBOOK,
 			displayName: raw.name,
@@ -214,6 +217,7 @@ export class FacebookStrategy<User> extends OAuth2Strategy<
 				familyName: raw.last_name,
 			},
 			emails: [{ value: raw.email }],
+			photos: [{ value: raw.picture }],
 			_json: raw,
 		};
 		return profile;


### PR DESCRIPTION
Hi there,

It looks like the profile `picture` field is part of the [default fields (](https://developers.facebook.com/docs/graph-api/reference/user/#fields)without requesting further permissions) so with this PR, this is included to the response following the same pattern used in the [Google strategy](https://github.com/TheRealFlyingCoder/remix-auth-socials/blob/main/src/strategies/google.ts#L137).

Finally, here's [another example](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/providers/facebook.ts#L27-L41) of `next-auth` including the profile picture.