### PR TITLE
Add Google hd and login_prompt params

### DIFF
--- a/src/strategies/google.ts
+++ b/src/strategies/google.ts
@@ -22,6 +22,8 @@ export type GoogleStrategyOptions = {
 	accessType?: 'online' | 'offline';
 	includeGrantedScopes?: boolean;
 	prompt?: 'none' | 'consent' | 'select_account';
+	hd?: string;
+	loginHint?: string
 };
 
 export type GoogleProfile = {
@@ -71,6 +73,10 @@ export class GoogleStrategy<User> extends OAuth2Strategy<
 
 	private readonly includeGrantedScopes: boolean;
 
+	private readonly hd?: string
+
+	private readonly loginHint?: string
+
 	private readonly userInfoURL =
 		'https://www.googleapis.com/oauth2/v3/userinfo';
 
@@ -83,6 +89,8 @@ export class GoogleStrategy<User> extends OAuth2Strategy<
 			accessType,
 			includeGrantedScopes,
 			prompt,
+			hd,
+			loginHint,
 		}: GoogleStrategyOptions,
 		verify: StrategyVerifyCallback<
 			User,
@@ -104,6 +112,8 @@ export class GoogleStrategy<User> extends OAuth2Strategy<
 		this.accessType = accessType ?? 'online';
 		this.includeGrantedScopes = includeGrantedScopes ?? false;
 		this.prompt = prompt;
+		this.hd = hd;
+		this.loginHint = loginHint;
 	}
 
 	protected authorizationParams(): URLSearchParams {
@@ -114,6 +124,12 @@ export class GoogleStrategy<User> extends OAuth2Strategy<
 		});
 		if (this.prompt) {
 			params.set('prompt', this.prompt);
+		}
+		if (this.hd) {
+			params.set('hd', this.hd)
+		}
+		if (this.loginHint) {
+			params.set('login_hint', this.loginHint)
 		}
 		return params;
 	}


### PR DESCRIPTION
Allows using the hd and login_prompt parameters to optimize the accounts that are shown on the Google OAuth consent screen. These parameters are documented here: https://developers.google.com/identity/protocols/oauth2/openid-connect

`npm run lint` did not pass, but errors were in the Facebook strategy which this PR did not touch.